### PR TITLE
Initialize MkDocs site with Decap CMS

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,22 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# cluster-doc
+# Cluster Documentation Website
+
+This repository contains the source for a documentation site built with **MkDocs** using the Material theme. Updates can be made through **Decap CMS** or by editing Markdown files directly. A GitHub Actions workflow automatically rebuilds the site on every push.
+
+## Features
+
+- **Material for MkDocs** with placeholder logo and favicon
+- Support for both English and Thai fonts
+- Search with syntax highlighting and code blocks
+
+- Sitemap and `robots.txt` automatically generated
+- Revision date shown for every page
+- Optional analytics hook
+  (update the tracking ID in `mkdocs.yml` to enable)
+
+## Local Development
+
+1. Install Python and `pip`.
+2. Install dependencies from `requirements.txt`:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Serve the site locally:
+
+   ```bash
+   mkdocs serve
+   ```
+
+4. Build the static site:
+
+   ```bash
+   mkdocs build
+   ```
+
+The site will be available at <http://localhost:8000>.
+
+## CMS
+
+An integrated CMS is available at `/admin/`. It allows uploading files and maintaining scripts for power users.
+
+## Deployment
+
+GitHub Actions builds the site and deploys it to the `gh-pages` branch which can be published with GitHub Pages.
+
+## Privacy
+
+No personal data is collected by default. If analytics are enabled, ensure you comply with your organization's privacy policy and relevant regulations.
+

--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -1,0 +1,24 @@
+backend:
+  name: git-gateway
+  branch: main
+
+media_folder: "docs/uploads"
+public_folder: "/uploads"
+
+collections:
+  - name: pages
+    label: Pages
+    folder: docs
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Body", name: "body", widget: "markdown" }
+  - name: scripts
+    label: Scripts
+    folder: docs/scripts
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - { label: "Description", name: "description", widget: "string" }
+      - { label: "Script File", name: "file", widget: "file" }

--- a/docs/admin/index.html
+++ b/docs/admin/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Cluster Documentation CMS</title>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </head>
+  <body>
+    <script>
+      window.CMS_MANUAL_INIT = true;
+    </script>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms-app.js"></script>
+    <script>
+      CMS.init({ config: { load_config_file: true, config_url: 'config.yml' } });
+    </script>
+  </body>
+</html>

--- a/docs/images/favicon.png
+++ b/docs/images/favicon.png
@@ -1,0 +1,2 @@
+Placeholder favicon image
+Replace this file with an actual PNG image.

--- a/docs/images/logo.png
+++ b/docs/images/logo.png
@@ -1,0 +1,2 @@
+Placeholder logo image
+Replace this file with an actual PNG image.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# Welcome to the Cluster Documentation
+
+This site provides documentation for both normal users and system administrators.
+
+Use the navigation bar at the top to browse available topics. You can contribute updates through the integrated CMS or by editing Markdown files directly.
+
+Fonts are loaded to support both English and Thai content. Syntax-highlighted code blocks and a search box make it easy to find what you need.
+

--- a/docs/javascripts/analytics.js
+++ b/docs/javascripts/analytics.js
@@ -1,0 +1,6 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+if (typeof gtag === 'function') {
+  gtag('js', new Date());
+  gtag('config', 'UA-XXXXXX-Y');
+}

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow:
+Sitemap: https://example.com/cluster-doc/sitemap.xml

--- a/docs/scripts/index.md
+++ b/docs/scripts/index.md
@@ -1,0 +1,3 @@
+# Cluster Scripts
+
+This section contains scripts useful for cluster administration.

--- a/docs/scripts/placeholder.sh
+++ b/docs/scripts/placeholder.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Example script for cluster administration
+
+echo "Placeholder script"

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,8 @@
+/* Custom styles for Cluster Documentation */
+@import url('https://fonts.googleapis.com/css2?family=Roboto&family=Noto+Sans+Thai&display=swap');
+
+:root {
+  --md-text-font: 'Roboto', 'Noto Sans Thai', sans-serif;
+  --md-code-font: 'Fira Code', monospace;
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,59 @@
+site_name: Cluster Documentation
+site_description: Documentation for normal users and system admins
+site_url: https://example.com/cluster-doc
+repo_url: https://github.com/example/cluster-doc
+
+nav:
+  - Home: index.md
+  - Scripts:
+      - scripts/index.md
+
+theme:
+  name: material
+  logo: images/logo.png
+  favicon: images/favicon.png
+  language: en
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - toc.integrate
+    - search.suggest
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Roboto
+    code: Fira Code
+
+markdown_extensions:
+  - admonition
+  - codehilite
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - git-revision-date-localized
+  - sitemap
+  - minify
+
+extra_javascript:
+  - https://www.googletagmanager.com/gtag/js?id=UA-XXXXXX-Y
+  - javascripts/analytics.js
+
+extra_templates:
+  - robots.txt
+
+extra:
+  analytics:
+    provider: google
+    property: UA-XXXXXX-Y
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/example/cluster-doc
+
+
+extra_css:
+  - stylesheets/extra.css
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs
+mkdocs-material
+mkdocs-git-revision-date-localized
+mkdocs-minify-plugin


### PR DESCRIPTION
## Summary
- set up MkDocs site using Material theme
- enable editing through Decap CMS
- add workflow to deploy to GitHub Pages
- add placeholder script and CSS
- document development workflow in README
- add placeholder logo and favicon
- enable Thai and English fonts and analytics hook
- configure sitemap, robots.txt, and navigation
- convert placeholder PNG files to text
- add requirements file and use it in workflow

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `mkdocs build` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685d331f1980832fa5c49dc704e2470c