### PR TITLE
Enable dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the source for a documentation site built with **MkDocs
 
 - **Material for MkDocs** with placeholder logo and favicon
 - Support for both English and Thai fonts
+- Automatic dark mode that follows the system theme
 - Search with syntax highlighting and code blocks
 
 - Sitemap and `robots.txt` automatically generated

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,4 +5,5 @@ This site provides documentation for both normal users and system administrators
 Use the navigation bar at the top to browse available topics. You can contribute updates through the integrated CMS or by editing Markdown files directly.
 
 Fonts are loaded to support both English and Thai content. Syntax-highlighted code blocks and a search box make it easy to find what you need.
+The theme automatically switches between light and dark modes based on your system preference.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,21 @@ theme:
   font:
     text: Roboto
     code: Fira Code
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- enable Material theme's dark mode with automatic system detection
- mention dark mode in project README
- describe theme switching on the front page

## Testing
- `mkdocs build -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c97fbe50832fa77ce78ae610139d