### PR TITLE
Add instructions for manual theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the source for a documentation site built with **MkDocs
 
 - **Material for MkDocs** with placeholder logo and favicon
 - Support for both English and Thai fonts
-- Automatic dark mode that follows the system theme
+- Automatic dark mode that follows the system theme and a manual toggle in the header
 - Search with syntax highlighting and code blocks
 
 - Sitemap and `robots.txt` automatically generated

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,5 +5,5 @@ This site provides documentation for both normal users and system administrators
 Use the navigation bar at the top to browse available topics. You can contribute updates through the integrated CMS or by editing Markdown files directly.
 
 Fonts are loaded to support both English and Thai content. Syntax-highlighted code blocks and a search box make it easy to find what you need.
-The theme automatically switches between light and dark modes based on your system preference.
+Use the sun/moon icon at the top right of the page to toggle between light and dark themes at any time.
 


### PR DESCRIPTION
## Summary
- describe how to manually switch between light and dark themes on the site
- note the manual theme toggle in the README

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6868cc924030832f9d5e1edf7e8514ff