### PR TITLE
Add Slurm basics outline

### DIFF
--- a/docs/slurm-basics.md
+++ b/docs/slurm-basics.md
@@ -1,0 +1,42 @@
+# Slurm Cluster Basics
+
+This page outlines the key topics usually included in cluster documentation when Slurm is the workload manager.
+
+## 1. Overview
+- Purpose of the cluster and typical workloads
+- Key policies or usage agreements
+
+## 2. Accessing the Cluster
+- SSH login instructions
+- Account creation and password policies
+
+## 3. Environment Setup
+- Loading modules for compilers, MPI, and applications
+- Creating virtual environments or user software stacks
+
+## 4. Submitting Batch Jobs
+- Basic `sbatch` script structure
+- Example Slurm directives (`--partition`, `--nodes`, `--time`, `--mem`)
+- Checking job status with `squeue`
+
+## 5. Running Interactive Jobs
+- Using `srun` for interactive sessions
+- Requesting GPUs or other resources
+
+## 6. Monitoring and Managing Jobs
+- Viewing queued and running jobs
+- Retrieving job history with `sacct`
+- Canceling jobs with `scancel`
+
+## 7. Storage and File Systems
+- Home vs. scratch storage locations
+- Data management best practices
+
+## 8. Helpful Commands
+- Common Slurm utilities (`sinfo`, `scontrol`, etc.)
+- Tips for troubleshooting job issues
+
+## 9. Getting Help
+- Documentation links and built-in `man` pages
+- Contact information for cluster support staff
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_url: https://github.com/example/cluster-doc
 
 nav:
   - Home: index.md
+  - Slurm Basics: slurm-basics.md
   - Scripts:
       - scripts/index.md
 


### PR DESCRIPTION
## Summary
- create new `docs/slurm-basics.md` outlining topics for cluster docs
- include the new page in the MkDocs navigation

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6868cdd9d1a0832fba6d802e4938e814