### PR TITLE
Add additional themes and accessibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains the source for a documentation site built with **MkDocs
 - **Material for MkDocs** with placeholder logo and favicon
 - Support for both English and Thai fonts
 - Automatic dark mode that follows the system theme and a manual toggle in the header
+- Additional color schemes including a **Dracula** theme and a **High Contrast** theme for accessibility
+- Floating controls to increase or decrease the font size for easier reading
 - Search with syntax highlighting and code blocks
 
 - Sitemap and `robots.txt` automatically generated

--- a/docs/javascripts/accessibility.js
+++ b/docs/javascripts/accessibility.js
@@ -1,0 +1,42 @@
+(function(){
+  const root = document.documentElement;
+  const storage = window.localStorage;
+
+  function setFontSize(size) {
+    if(size === 'normal') {
+      root.removeAttribute('data-font-size');
+      storage.removeItem('doc-font-size');
+    } else {
+      root.setAttribute('data-font-size', size);
+      storage.setItem('doc-font-size', size);
+    }
+  }
+
+  function applyStoredSize() {
+    const stored = storage.getItem('doc-font-size');
+    if(stored) root.setAttribute('data-font-size', stored);
+  }
+
+  function createControls(){
+    const container = document.createElement('div');
+    container.className = 'font-size-controls';
+    container.innerHTML = '<button class="font-size-decrease" aria-label="Decrease font">A-</button>'+
+                          '<button class="font-size-increase" aria-label="Increase font">A+</button>';
+    document.body.appendChild(container);
+    container.querySelector('.font-size-increase').addEventListener('click', ()=>{
+      const current = root.getAttribute('data-font-size') || 'normal';
+      if(current === 'normal') setFontSize('large');
+      else if(current === 'large') setFontSize('xlarge');
+    });
+    container.querySelector('.font-size-decrease').addEventListener('click', ()=>{
+      const current = root.getAttribute('data-font-size') || 'normal';
+      if(current === 'xlarge') setFontSize('large');
+      else if(current === 'large') setFontSize('normal');
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    applyStoredSize();
+    createControls();
+  });
+})();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -6,3 +6,47 @@
   --md-code-font: 'Fira Code', monospace;
 }
 
+/* Dracula color scheme */
+[data-md-color-scheme="dracula"] {
+  --md-hue: 275;
+  --md-primary-fg-color: #ff79c6;
+  --md-primary-bg-color: #282a36;
+  --md-accent-fg-color: #50fa7b;
+  --md-default-bg-color: #282a36;
+  --md-default-fg-color: #f8f8f2;
+}
+
+/* High contrast color scheme for accessibility */
+[data-md-color-scheme="high-contrast"] {
+  --md-primary-fg-color: #000000;
+  --md-primary-bg-color: #ffffff;
+  --md-accent-fg-color: #ffff00;
+  --md-default-bg-color: #ffffff;
+  --md-default-fg-color: #000000;
+}
+
+/* Font size controls */
+html[data-font-size="large"] {
+  font-size: 112%;
+}
+
+html[data-font-size="xlarge"] {
+  font-size: 125%;
+}
+
+.font-size-controls {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: var(--md-default-bg-color);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+
+.font-size-controls button {
+  margin: 0 0.25rem;
+  font-size: 1rem;
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,18 @@ theme:
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
+    - scheme: dracula
+      primary: deep purple
+      accent: pink
+      toggle:
+        icon: material/ghost
+        name: Switch to Dracula mode
+    - scheme: high-contrast
+      primary: black
+      accent: yellow
+      toggle:
+        icon: material/eye
+        name: Switch to high contrast mode
 
 markdown_extensions:
   - admonition
@@ -55,7 +67,8 @@ plugins:
   - git-revision-date-localized
   - minify
 
-extra_javascript: []
+extra_javascript:
+  - javascripts/accessibility.js
 
 extra_templates:
   - robots.txt


### PR DESCRIPTION
## Summary
- allow theme selection for dracula and high contrast
- add floating font-size controls
- document new features

## Testing
- `mkdocs build -q` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868d4d0ce18832fbc0a372e1a54766b