### PR TITLE
Add details to Slurm guides

### DIFF
--- a/docs/slurm-basics.md
+++ b/docs/slurm-basics.md
@@ -1,42 +1,15 @@
 # Slurm Cluster Basics
 
-This page outlines the key topics usually included in cluster documentation when Slurm is the workload manager.
+This page provides quick links to detailed guides for using the cluster.
+Follow each link for step-by-step instructions and examples of common
+commands.
 
-## 1. Overview
-- Purpose of the cluster and typical workloads
-- Key policies or usage agreements
-
-## 2. Accessing the Cluster
-- SSH login instructions
-- Account creation and password policies
-
-## 3. Environment Setup
-- Loading modules for compilers, MPI, and applications
-- Creating virtual environments or user software stacks
-
-## 4. Submitting Batch Jobs
-- Basic `sbatch` script structure
-- Example Slurm directives (`--partition`, `--nodes`, `--time`, `--mem`)
-- Checking job status with `squeue`
-
-## 5. Running Interactive Jobs
-- Using `srun` for interactive sessions
-- Requesting GPUs or other resources
-
-## 6. Monitoring and Managing Jobs
-- Viewing queued and running jobs
-- Retrieving job history with `sacct`
-- Canceling jobs with `scancel`
-
-## 7. Storage and File Systems
-- Home vs. scratch storage locations
-- Data management best practices
-
-## 8. Helpful Commands
-- Common Slurm utilities (`sinfo`, `scontrol`, etc.)
-- Tips for troubleshooting job issues
-
-## 9. Getting Help
-- Documentation links and built-in `man` pages
-- Contact information for cluster support staff
-
+- [Overview](slurm/overview.md)
+- [Accessing the Cluster](slurm/accessing.md)
+- [Environment Setup](slurm/environment.md)
+- [Submitting Batch Jobs](slurm/batch-jobs.md)
+- [Running Interactive Jobs](slurm/interactive-jobs.md)
+- [Monitoring and Managing Jobs](slurm/job-management.md)
+- [Storage and File Systems](slurm/storage.md)
+- [Helpful Commands](slurm/helpful-commands.md)
+- [Getting Help](slurm/help.md)

--- a/docs/slurm/accessing.md
+++ b/docs/slurm/accessing.md
@@ -1,0 +1,27 @@
+# Accessing the Cluster
+
+### SSH Login
+
+Use SSH to connect to the login node:
+
+```bash
+ssh <username>@cluster.example.com
+```
+
+Replace `<username>` with your account name. The first time you log in,
+you may be asked to verify the host key. Some institutions require
+connecting through a VPN or multi-factor authentication, so consult your
+local IT instructions if you encounter connection issues.
+
+### Account Creation
+
+Accounts are provisioned by the cluster administrators. After your
+account is created, log in and change your password with:
+
+```bash
+passwd
+```
+
+Choose a strong password and never share it with others.
+
+For details about connecting with OpenSSH see the [official manual](https://www.openssh.com/manual.html).

--- a/docs/slurm/batch-jobs.md
+++ b/docs/slurm/batch-jobs.md
@@ -1,0 +1,35 @@
+# Submitting Batch Jobs
+
+Prepare a job script and submit it with `sbatch`.
+
+### Example Script
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=test
+#SBATCH --partition=general
+#SBATCH --nodes=1
+#SBATCH --time=01:00:00
+#SBATCH --mem=4G
+#SBATCH --output=slurm-%j.out
+
+# Request one GPU if needed
+#SBATCH --gres=gpu:1
+
+srun my_application
+```
+
+Submit the job:
+
+```bash
+sbatch job.sh
+```
+
+Check its status with:
+
+```bash
+squeue -u $USER
+```
+
+See the [sbatch documentation](https://slurm.schedmd.com/sbatch.html) for
+additional directives such as email notifications or array jobs.

--- a/docs/slurm/environment.md
+++ b/docs/slurm/environment.md
@@ -1,0 +1,38 @@
+# Environment Setup
+
+The cluster uses environment modules to manage compilers, MPI libraries
+and application software. Modules allow you to easily switch between
+different versions of tools without altering your shell configuration.
+
+### Loading Modules
+
+View available modules with:
+
+```bash
+module avail
+```
+
+List currently loaded modules with `module list` and reset your
+environment using `module purge` if needed.
+
+Load a compiler or application module, for example:
+
+```bash
+module load gcc/12.1.0
+module load openmpi
+```
+
+### Virtual Environments
+
+To create a Python virtual environment for your own software stack:
+
+```bash
+module load python
+python -m venv ~/envs/myenv
+source ~/envs/myenv/bin/activate
+```
+
+Install packages as needed in the activated environment.
+
+See the [Lmod documentation](https://lmod.readthedocs.io/en/latest/) for
+more module commands and examples.

--- a/docs/slurm/help.md
+++ b/docs/slurm/help.md
@@ -1,0 +1,21 @@
+# Getting Help
+
+### Documentation
+
+Slurm provides extensive manual pages. For example:
+
+```bash
+man sbatch
+```
+
+You can view help for most commands with the `--help` flag, and the
+official documentation is available online at
+[https://slurm.schedmd.com/documentation.html](https://slurm.schedmd.com/documentation.html).
+
+Additional guides may be found on the cluster website.
+
+### Contact Support
+
+If you encounter problems, email `cluster-support@example.com` or open a
+support ticket through the service portal. Include your job ID and any
+error messages to help staff diagnose the issue.

--- a/docs/slurm/helpful-commands.md
+++ b/docs/slurm/helpful-commands.md
@@ -1,0 +1,17 @@
+# Helpful Commands
+
+### Slurm Utilities
+
+- `sinfo` – view available partitions and nodes
+- `scontrol show job <jobid>` – detailed job information
+- `squeue -l` – extended job listing
+
+Use `sinfo` frequently to check which partitions are available. The
+official man page provides a full description of its output at
+[slurm.schedmd.com/sinfo.html](https://slurm.schedmd.com/sinfo.html).
+
+### Troubleshooting Tips
+
+Check your job's output and error files if it fails to run. The command
+`scontrol show job <jobid>` often provides clues about resource or
+configuration issues.

--- a/docs/slurm/interactive-jobs.md
+++ b/docs/slurm/interactive-jobs.md
@@ -1,0 +1,28 @@
+# Running Interactive Jobs
+
+Interactive sessions are useful for debugging or running short tasks.
+
+### Basic Usage
+
+Request an interactive shell with:
+
+```bash
+srun --pty bash
+```
+
+Specify resources such as the partition, CPUs, or runtime to avoid using
+defaults that may not suit your workload:
+
+```bash
+srun --partition=general --time=30:00 --cpus-per-task=4 --pty bash
+```
+
+### Requesting GPUs
+
+To run on a GPU, ask for the resource explicitly:
+
+```bash
+srun --gres=gpu:1 --pty bash
+```
+Add other options such as memory or time limits as needed. More examples
+are available in the [srun documentation](https://slurm.schedmd.com/srun.html).

--- a/docs/slurm/job-management.md
+++ b/docs/slurm/job-management.md
@@ -1,0 +1,36 @@
+# Monitoring and Managing Jobs
+
+### Viewing Jobs
+
+See your queued or running jobs with:
+
+```bash
+squeue -u $USER
+```
+Add `-p <partition>` to filter by partition. Refer to the
+[squeue documentation](https://slurm.schedmd.com/squeue.html) for more
+options.
+
+### Job History
+
+After a job finishes, view its history using:
+
+```bash
+sacct -j <jobid>
+```
+Specify a start time with `-S` to view older records:
+
+```bash
+sacct -S yesterday
+```
+
+### Canceling Jobs
+
+Stop a running or pending job with:
+
+```bash
+scancel <jobid>
+```
+You can cancel all of your jobs with `scancel -u $USER`. See the
+[scancel documentation](https://slurm.schedmd.com/scancel.html) for
+additional usage details.

--- a/docs/slurm/overview.md
+++ b/docs/slurm/overview.md
@@ -1,0 +1,15 @@
+# Overview
+
+The cluster provides high-performance computing resources for research and
+analysis tasks. Typical workloads include simulations, data processing,
+training machine learning models, and other compute-intensive jobs. Nodes
+are equipped with modern CPUs and select partitions include GPUs for
+accelerated workloads.
+
+### Policies and Usage Agreements
+
+Users must comply with institutional policies and only run authorized
+workloads. Do not share accounts or run services unrelated to your
+research. Refer to the [HPC usage policy](https://example.com/hpc-policy)
+for details. Contact the administrators if you are unsure about any
+usage restrictions.

--- a/docs/slurm/storage.md
+++ b/docs/slurm/storage.md
@@ -1,0 +1,17 @@
+# Storage and File Systems
+
+### Home and Scratch
+
+Your home directory is backed up and should be used for important files
+and scripts. Scratch space provides larger, high-performance storage for
+running jobs and temporary data.
+
+### Best Practices
+
+- Run jobs from scratch to avoid filling home quotas.
+- Clean up large files when they are no longer needed.
+- Keep personal backups of critical data.
+- Check your quota with `lfs quota /scratch/$USER` if available.
+
+More details about the storage layout are available from the
+[cluster storage guide](https://example.com/cluster-storage).


### PR DESCRIPTION
## Summary
- link guides from Slurm Cluster Basics and clarify instructions
- expand content on accessing the cluster
- extend job examples for batch and interactive sessions
- add references to official Slurm documentation

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6868d434c7b4832f916c7acc79c57d71