### PR TITLE
Add module and container docs

### DIFF
--- a/docs/apptainer.md
+++ b/docs/apptainer.md
@@ -1,0 +1,40 @@
+# Apptainer Containers
+
+Apptainer (formerly Singularity) allows you to run containerized applications without requiring administrator privileges. It is commonly used to package software stacks for HPC clusters.
+
+### Loading the Apptainer Module
+
+First load the module provided by the cluster:
+
+```bash
+module load apptainer
+```
+
+### Obtaining an Image
+
+You can pull a pre-built image from an online registry or build one yourself. To download from Docker Hub:
+
+```bash
+apptainer pull ubuntu.sif docker://ubuntu:22.04
+```
+
+### Running the Container
+
+Execute commands inside the container with `run` or `exec`:
+
+```bash
+apptainer run ubuntu.sif
+apptainer exec ubuntu.sif /bin/bash
+```
+
+### Building Your Own Image
+
+If you have a definition file named `recipe.def` you can build a SIF image:
+
+```bash
+apptainer build my_image.sif recipe.def
+```
+
+Apptainer will create the container in the current directory. You can then distribute the single SIF file to other systems.
+
+See the official [Apptainer documentation](https://apptainer.org/docs/) for more options and configuration details.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,43 @@
+# Using Modules
+
+Environment modules allow you to easily switch between different versions of software on the cluster. The module command is provided by Lmod.
+
+### Listing Modules
+
+View everything that is available:
+
+```bash
+module avail
+```
+
+If you are looking for a particular package, search by name:
+
+```bash
+module spider <package>
+```
+
+### Loading a Module
+
+Once you know the module name, load it into your environment:
+
+```bash
+module load gcc/12.1.0
+```
+
+List what is currently active with:
+
+```bash
+module list
+```
+
+Reset your environment and unload all modules with `module purge`.
+
+### Checking the Module System Version
+
+To see the installed Lmod version run:
+
+```bash
+module --version
+```
+
+More details and examples can be found in the [Environment Setup guide](slurm/environment.md).

--- a/docs/singularity.md
+++ b/docs/singularity.md
@@ -1,0 +1,38 @@
+# Singularity Containers
+
+Singularity was the original name of Apptainer. Many clusters still ship the command as `singularity`.
+
+### Loading the Singularity Module
+
+If available, load it like any other module:
+
+```bash
+module load singularity
+```
+
+### Downloading an Image
+
+Images can be pulled from remote registries or local paths. For example:
+
+```bash
+singularity pull alpine.sif docker://alpine:latest
+```
+
+### Using the Image
+
+Run a shell inside the container or execute a specific program:
+
+```bash
+singularity shell alpine.sif
+singularity exec alpine.sif cat /etc/os-release
+```
+
+### Building Custom Images
+
+With a definition file you can create your own container:
+
+```bash
+singularity build custom.sif Singularity.def
+```
+
+Refer to the [Singularity documentation](https://sylabs.io/guides/) for a complete walkthrough of advanced features and configuration options.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,9 @@ nav:
   - Home: index.md
   - Slurm Basics: slurm-basics.md
   - IST-CLUSTER Guide: ist-cluster.md
+  - Using Modules: modules.md
+  - Apptainer: apptainer.md
+  - Singularity: singularity.md
   - Scripts:
       - scripts/index.md
 


### PR DESCRIPTION
## Summary
- document using environment modules
- add Apptainer container instructions
- add Singularity container instructions
- update navigation to include new pages

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6868d8d8b288832fbee203022f627dc3