### PR TITLE
Add Mamba/Anaconda usage guide

### DIFF
--- a/docs/slurm-basics.md
+++ b/docs/slurm-basics.md
@@ -7,6 +7,7 @@ commands.
 - [Overview](slurm/overview.md)
 - [Accessing the Cluster](slurm/accessing.md)
 - [Environment Setup](slurm/environment.md)
+- [Mamba/Anaconda Environments](slurm/mamba-anaconda.md)
 - [Submitting Batch Jobs](slurm/batch-jobs.md)
 - [Running Interactive Jobs](slurm/interactive-jobs.md)
 - [Monitoring and Managing Jobs](slurm/job-management.md)

--- a/docs/slurm/environment.md
+++ b/docs/slurm/environment.md
@@ -34,5 +34,8 @@ source ~/envs/myenv/bin/activate
 
 Install packages as needed in the activated environment.
 
+For a Conda-based workflow using Mamba or Anaconda, see
+[Mamba/Anaconda Environments](mamba-anaconda.md).
+
 See the [Lmod documentation](https://lmod.readthedocs.io/en/latest/) for
 more module commands and examples.

--- a/docs/slurm/mamba-anaconda.md
+++ b/docs/slurm/mamba-anaconda.md
@@ -1,0 +1,38 @@
+# Mamba/Anaconda Environments
+
+Mamba is a drop-in replacement for the `conda` package manager that
+resolves dependencies faster. Both tools can create isolated
+Python environments. Load the provided module and create a new
+environment as follows:
+
+```bash
+module load mamba  # or module load anaconda
+mamba create -y -n myenv python=3.10
+conda activate myenv
+```
+
+Install packages inside the activated environment:
+
+```bash
+mamba install numpy pandas
+```
+
+To use the environment in a Slurm job script, load the module and
+activate the environment before running your program:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=conda-test
+#SBATCH --partition=general
+#SBATCH --time=00:10:00
+
+module load mamba
+conda activate myenv
+srun python script.py
+```
+
+Export the environment specification if you need to recreate it later:
+
+```bash
+conda env export > myenv.yml
+```


### PR DESCRIPTION
## Summary
- document how to create and use Mamba/Anaconda environments
- link the new guide from the basics overview
- reference the guide from the environment setup page

## Testing
- `pip install -r requirements.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6868d9e72328832f8ae18d8f846874bd