### PR TITLE
Add sinfo output parser

### DIFF
--- a/docs/scripts/sinfo-to-page.md
+++ b/docs/scripts/sinfo-to-page.md
@@ -1,0 +1,38 @@
+# Converting `sinfo` Output to Markdown
+
+This script reads the text output from the `sinfo` command and generates a Markdown summary for each partition.
+
+## Usage
+
+1. Save the output of `sinfo` to a file:
+   ```bash
+   sinfo > sinfo.txt
+   ```
+2. Run the conversion script:
+   ```bash
+   python docs/scripts/sinfo_to_markdown.py sinfo.txt > partitions.md
+   ```
+3. Open `partitions.md` in a viewer or add it to the documentation site.
+
+## Example
+
+Given an input file containing:
+
+```text
+PARTITION         AVAIL  TIMELIMIT  NODES  STATE NODELIST
+cpu*                 up 7-00:00:00      4   idle ist-compute-1-[001-004]
+```
+
+the generated Markdown looks like:
+
+```markdown
+## Partition `cpu*`
+
+- **Availability:** up
+- **Time limit:** 7-00:00:00
+
+| State | Nodes | Node list |
+|-------|-------|-----------|
+| idle | 4 | ist-compute-1-[001-004] |
+```
+

--- a/docs/scripts/sinfo_to_markdown.py
+++ b/docs/scripts/sinfo_to_markdown.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+
+def parse_sinfo(file_path):
+    data = defaultdict(lambda: {"avail": "", "timelimit": "", "rows": []})
+    with open(file_path) as f:
+        lines = [line.strip() for line in f if line.strip()]
+    if not lines:
+        raise ValueError("Input file is empty")
+    header = lines[0]
+    cols = header.split()
+    if len(cols) < 6 or cols[0].lower() != "partition":
+        raise ValueError("Unexpected file format")
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        partition = parts[0]
+        avail = parts[1]
+        timelimit = parts[2]
+        nodes = parts[3]
+        state = parts[4]
+        nodelist = " ".join(parts[5:])
+        entry = {"state": state, "nodes": nodes, "nodelist": nodelist}
+        group = data[partition]
+        if not group["avail"]:
+            group["avail"] = avail
+        if not group["timelimit"]:
+            group["timelimit"] = timelimit
+        group["rows"].append(entry)
+    return data
+
+
+def generate_markdown(data):
+    out_lines = []
+    for part in sorted(data):
+        info = data[part]
+        out_lines.append(f"## Partition `{part}`")
+        out_lines.append("")
+        out_lines.append(f"- **Availability:** {info['avail']}")
+        out_lines.append(f"- **Time limit:** {info['timelimit']}")
+        out_lines.append("")
+        out_lines.append("| State | Nodes | Node list |")
+        out_lines.append("|-------|-------|-----------|")
+        for row in info["rows"]:
+            out_lines.append(f"| {row['state']} | {row['nodes']} | {row['nodelist']} |")
+        out_lines.append("")
+    return "\n".join(out_lines)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python sinfo_to_markdown.py <sinfo_output.txt>")
+        sys.exit(1)
+    path = Path(sys.argv[1])
+    if not path.is_file():
+        print(f"File not found: {path}")
+        sys.exit(1)
+    data = parse_sinfo(path)
+    md = generate_markdown(data)
+    print(md)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - File Transfer: tools/file-transfer.md
   - Scripts:
       - scripts/index.md
+      - Convert sinfo output: scripts/sinfo-to-page.md
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- add a Python script that converts `sinfo` output to markdown
- document how to use the script
- add the new documentation page to mkdocs navigation

## Testing
- `python -m py_compile docs/scripts/sinfo_to_markdown.py`

------
https://chatgpt.com/codex/tasks/task_e_6868dd9bfc84832fb8acf9d5637b139d