### PR TITLE
Add interactive sessions guide

### DIFF
--- a/docs/slurm/interactive-sessions.md
+++ b/docs/slurm/interactive-sessions.md
@@ -1,0 +1,41 @@
+# Interactive Sessions
+
+Interactive sessions let you run commands on a compute node and see the output immediately. They are best for debugging or short exploratory tasks.
+
+## When to Use an Interactive Session
+
+- Testing and debugging job scripts before submitting them as batch jobs
+- Running quick commands that require immediate feedback
+- Launching interactive tools such as Jupyter notebooks or GUI applications
+- Exploring the environment or installing software interactively
+
+For long-running workloads that do not require live interaction, submit a batch job instead of keeping an interactive session open.
+
+## Starting an Interactive Session
+
+Request a shell on a compute node with `srun`:
+
+```bash
+srun --pty bash
+```
+
+Specify resources to match your needs:
+
+```bash
+srun --partition=general --time=30:00 --cpus-per-task=4 --mem=4G --pty bash
+```
+
+To work on a GPU node, include the `--gres` option:
+
+```bash
+srun --gres=gpu:1 --pty bash
+```
+
+## Ending the Session
+
+When finished, exit the shell to release the resources:
+
+```bash
+exit
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
       - Environment Setup: slurm/environment.md
       - Submitting Batch Jobs: slurm/batch-jobs.md
       - Running Interactive Jobs: slurm/interactive-jobs.md
+      - Interactive Sessions: slurm/interactive-sessions.md
       - MPI and Multi-node Jobs: slurm/mpi-multinode.md
       - Monitoring and Managing Jobs: slurm/job-management.md
       - Storage and File Systems: slurm/storage.md


### PR DESCRIPTION
## Summary
- add documentation for running interactive sessions
- include new page in MkDocs navigation

## Testing
- `mkdocs build -q`


------
https://chatgpt.com/codex/tasks/task_e_6868de11d1f0832f8ba69217a4e25bfb