### PR TITLE
Add Slurm preemption guide

### DIFF
--- a/docs/slurm/preemption.md
+++ b/docs/slurm/preemption.md
@@ -1,0 +1,46 @@
+# Preemption
+
+Preemption allows high priority jobs to run by pausing or terminating running low priority jobs. It is typically enabled on a dedicated partition or for jobs marked as preemptible.
+
+### Why Preempt Jobs?
+
+- Ensure urgent computations start quickly when resources are scarce.
+- Keep hardware free for high priority workloads.
+- Allow opportunistic jobs to use idle resources without delaying critical work.
+
+### How Preemption Works
+
+When a high priority job is scheduled and resources are unavailable, Slurm may preempt running jobs with lower priority. Depending on cluster configuration:
+
+- The job may be requeued and restarted later when resources free up.
+- The job may be canceled entirely.
+
+Preempted jobs that are requeued will start from the beginning unless your application supports checkpointing.
+
+### Submitting Preemptible Jobs
+
+Check available partitions with `sinfo`. Many clusters provide a partition named `preempt` (or similar) for jobs that can be interrupted.
+
+```bash
+#SBATCH --partition=preempt
+#SBATCH --requeue       # allow Slurm to requeue the job when preempted
+```
+
+Submit your script with `sbatch job.sh`. Use `squeue` to monitor status. Jobs in the preemptible partition may run immediately but can be stopped when resources are required elsewhere.
+
+### Effect on Your Job
+
+- Execution may stop at any time if a higher priority job needs the resources.
+- If `--requeue` was set and the partition allows it, the job is placed back in the queue and will restart from the beginning once resources are free.
+- If not requeued, the job will be canceled and you must resubmit it manually.
+
+### Good Use Cases
+
+Preemptible partitions are ideal for:
+
+- Long, low-priority simulations that do not need to finish quickly.
+- Opportunistic data analysis or testing that can be restarted.
+- Workloads with built-in checkpointing or frequent save points.
+
+Using preemptible resources lets you take advantage of otherwise idle hardware while ensuring that critical jobs are never delayed.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
       - Running Interactive Jobs: slurm/interactive-jobs.md
       - MPI and Multi-node Jobs: slurm/mpi-multinode.md
       - Monitoring and Managing Jobs: slurm/job-management.md
+      - Preemption: slurm/preemption.md
       - Storage and File Systems: slurm/storage.md
       - Helpful Commands: slurm/helpful-commands.md
       - Getting Help: slurm/help.md


### PR DESCRIPTION
## Summary
- add new page for Slurm preemption
- show how to submit jobs to a preemptible partition
- update nav to include the new page

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_6868de3cd688832fb07bf7b07b1bbd97