### PR TITLE
Improve Slurm job management docs

### DIFF
--- a/docs/slurm/job-management.md
+++ b/docs/slurm/job-management.md
@@ -11,6 +11,22 @@ Add `-p <partition>` to filter by partition. Refer to the
 [squeue documentation](https://slurm.schedmd.com/squeue.html) for more
 options.
 
+A typical `squeue` table looks like this:
+
+```
+ JOBID PARTITION     NAME     USER ST  TIME  NODES NODELIST(REASON)
+ 1234  general   myjob    alice  R  0:10      1   node01
+ 1235  general   myjob    alice  PD  0:00      1   (Priority)
+```
+
+The important columns are:
+
+- **JOBID** – the numeric identifier used with other commands
+- **ST** – the state of the job (`R` running, `PD` pending, `CG` completing, `CD` completed, `F` failed)
+- **NODELIST(REASON)** – either the node running the job or why it is waiting
+
+See the [Slurm job states documentation](https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATES) for the full list of codes.
+
 ### Job History
 
 After a job finishes, view its history using:
@@ -34,3 +50,14 @@ scancel <jobid>
 You can cancel all of your jobs with `scancel -u $USER`. See the
 [scancel documentation](https://slurm.schedmd.com/scancel.html) for
 additional usage details.
+
+### Viewing Job Priority
+
+Check a job's priority with:
+
+```bash
+sprio -j <jobid>
+```
+For more detail, run `scontrol show job <jobid>` and look for the `Priority` field.
+Slurm calculates priority from factors such as fairshare, job age, and QOS.
+See the [priority overview](https://slurm.schedmd.com/job_prio.html) on the Slurm website for an explanation of how it works.


### PR DESCRIPTION
## Summary
- expand the job management tutorial with instructions for `squeue`
- explain job state codes and example table output
- document cancelling all jobs and viewing job priority

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6868dfb7a0d0832f82f461a45751c151