### PR TITLE
Fix QoS policy data loading

### DIFF
--- a/docs/javascripts/load-qos.js
+++ b/docs/javascripts/load-qos.js
@@ -1,9 +1,13 @@
-document.addEventListener('DOMContentLoaded', function(){
-  fetch('qos-policy-data.txt')
+document.addEventListener('DOMContentLoaded', function () {
+  const pre = document.getElementById('qos-data');
+  if (!pre) return;
+
+  const url = pre.dataset.url || 'qos-policy-data.txt';
+
+  fetch(url)
     .then(resp => resp.text())
     .then(text => {
-      const pre = document.getElementById('qos-data');
-      if(pre) pre.textContent = text;
+      pre.textContent = text;
     })
     .catch(err => console.error('Failed to load QOS data:', err));
 });

--- a/docs/slurm/qos-policy.md
+++ b/docs/slurm/qos-policy.md
@@ -5,5 +5,5 @@ Slurm uses Quality of Service (QOS) rules to manage job priorities and resource 
 To update this page, paste the latest command output into `qos-policy-data.txt` in the same folder.
 
 <div class="qos-data-container">
-  <pre id="qos-data">Loading...</pre>
+  <pre id="qos-data" data-url="../qos-policy-data.txt">Loading...</pre>
 </div>


### PR DESCRIPTION
## Summary
- fix path to `qos-policy-data.txt`
- allow JS to use a configurable data URL for the QoS policy table

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6868e0a93c88832fb269f77db5ee6aba