### PR TITLE
Add copy button for code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains the source for a documentation site built with **MkDocs
 - Additional color schemes including a **Dracula** theme and a **High Contrast** theme for accessibility
 - Floating controls to increase or decrease the font size for easier reading
 - Search with syntax highlighting and code blocks
+- Easy copy button for all code snippets
 
 - Sitemap and `robots.txt` automatically generated
 - Revision date shown for every page

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ theme:
     - navigation.sections
     - toc.integrate
     - search.suggest
+    - content.code.copy
     - sitemap
   icon:
     repo: fontawesome/brands/github


### PR DESCRIPTION
## Summary
- enable the Material theme feature for copy buttons on code blocks
- document new feature in README

## Testing
- `mkdocs build --clean`

------
https://chatgpt.com/codex/tasks/task_e_6868e8f9f2c8832fb883a4dcb9016bb7