### PR TITLE
Improve security docs and pinned deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,12 @@ GitHub Actions builds the site and deploys it to the `gh-pages` branch which can
 
 No personal data is collected by default. If analytics are enabled, ensure you comply with your organization's privacy policy and relevant regulations.
 
+## Security
+
+Follow best practices when using the cluster:
+
+- Use strong SSH keys and keep them private.
+- Never share your account or run unauthorized services.
+- Review the [HPC usage policy](https://example.com/hpc-policy) referenced in the documentation.
+- Report vulnerabilities by following the instructions in [SECURITY.md](SECURITY.md).
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+If you discover a vulnerability, please email maintainer@example.com or open a private issue on GitHub.
+Do not disclose security issues publicly until we have addressed them.
+
+This project follows the HPC usage policy referenced in [docs/slurm/overview.md](docs/slurm/overview.md).
+

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow:
-Sitemap: https://example.com/cluster-doc/sitemap.xml
+Sitemap: https://wit543.github.io/cluster-doc/sitemap.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs
-mkdocs-material
-mkdocs-git-revision-date-localized-plugin
-mkdocs-minify-plugin
+mkdocs==1.5.3
+mkdocs-material==9.6.15
+mkdocs-git-revision-date-localized-plugin==1.2.0
+mkdocs-minify-plugin==0.7.1


### PR DESCRIPTION
## Summary
- add a security policy for reporting vulnerabilities
- document security best practices in the README
- update the sitemap URL in `robots.txt`
- pin package versions for MkDocs

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mkdocs==1.5.3)*
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6868e8cc0268832f9db60c2cf423e7d7