### PR TITLE
Add Terminalizer demo setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy Docs
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install terminalizer
+        run: npm install -g terminalizer
+      - name: Record sinfo demo
+        run: terminalizer record docs/scripts/sinfo-demo -c "bash docs/scripts/demo_sinfo.sh" --force
+      - name: Render gif
+        run: terminalizer render docs/scripts/sinfo-demo.yml -o docs/images/sinfo-demo
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - name: Deploy
+        run: mkdocs gh-deploy --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/docs/images/sinfo-demo.gif
+++ b/docs/images/sinfo-demo.gif
@@ -1,0 +1,1 @@
+GIF placeholder created by Codex. This file will be overwritten by Terminalizer.

--- a/docs/scripts/demo_sinfo.sh
+++ b/docs/scripts/demo_sinfo.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+cat <<'OUT'
+[root@ist-frontend-003 ~]# sinfo
+PARTITION         AVAIL  TIMELIMIT  NODES  STATE NODELIST
+cpu*                 up 7-00:00:00      4   idle ist-compute-1-[001-004]
+bash-cpu             up    2:00:00      1   idle ist-compute-1-004
+gpu-cluster          up 3-00:00:00      1  maint ist-gpu-03
+gpu-cluster          up 3-00:00:00     13    mix ist-gpu-[01-02,04-11,14-16]
+gpu-cluster          up 3-00:00:00      2   idle ist-gpu-[12-13]
+bash-gpu-cluster     up    2:00:00      1  maint ist-gpu-03
+bash-gpu-cluster     up    2:00:00     13    mix ist-gpu-[01-02,04-11,14-16]
+bash-gpu-cluster     up    2:00:00      2   idle ist-gpu-[12-13]
+scads                up 7-00:00:00      1   idle ist-dgx04
+scads-a100           up 5-00:00:00      2   idle ist-gpu-a100-[01-02]
+g-scads              up 5-00:00:00      2   idle ist-gpu-a100-[01-02]
+nrl-a100-deadline    up 10-00:00:0      1   idle ist-gpu-a100-02
+deadline             up 10-00:00:0      1  maint ist-gpu-03
+deadline             up 10-00:00:0     13    mix ist-gpu-[01-02,04-11,14-16]
+deadline             up 10-00:00:0      6   idle ist-compute-1-[001-004],ist-gpu-[12-13]
+a100-guest           up 3-00:00:00      2  maint ist-a100-[05-06]
+a100-guest           up 3-00:00:00      1    mix ist-a100-02
+a100-guest           up 3-00:00:00      3  alloc ist-a100-[01,03-04]
+a100                 up   infinite      2  maint ist-a100-[05-06]
+a100                 up   infinite      1    mix ist-a100-02
+a100                 up   infinite      3  alloc ist-a100-[01,03-04]
+OUT

--- a/docs/scripts/index.md
+++ b/docs/scripts/index.md
@@ -1,3 +1,11 @@
 # Cluster Scripts
 
 This section contains scripts useful for cluster administration.
+
+The repository uses [Terminalizer](https://github.com/faressoft/terminalizer)
+in the GitHub Actions workflow to automatically generate animated demos from
+terminal output. See `demo_sinfo.sh` for an example.
+
+Because this Codex environment cannot record real terminals, `docs/images/sinfo-demo.gif`
+is only a small text placeholder. When you run the workflow yourself,
+Terminalizer will generate the actual animation and overwrite the placeholder image.

--- a/docs/slurm/helpful-commands.md
+++ b/docs/slurm/helpful-commands.md
@@ -3,6 +3,13 @@
 ### Slurm Utilities
 
 - `sinfo` – view available partitions and nodes
+
+Below is an example of the command output captured with
+[`terminalizer`](https://github.com/faressoft/terminalizer). The `sinfo-demo.gif`
+image in this repository is just a tiny text placeholder; the GitHub Actions
+workflow will overwrite it with a real recording when it runs:
+
+![sinfo demo](../images/sinfo-demo.gif)
 - `scontrol show job <jobid>` – detailed job information
 - `squeue -l` – extended job listing
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that records a demo with Terminalizer
- include placeholder gif and demo script
- note that the placeholder gif will be replaced when workflow runs
- use text placeholder for sinfo demo

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6868eb932f64832fa9c1978e6cf25e9f