### PR TITLE
Add optional Google Analytics config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the source for a documentation site built with **MkDocs
 - Sitemap and `robots.txt` automatically generated
 - Revision date shown for every page
 - Optional analytics hook
-  (update the tracking ID in `mkdocs.yml` to enable)
+  (set the Google Analytics property in `mkdocs.yml` to enable)
 
 ## Local Development
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,10 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/wit543/cluster-doc
 
+  analytics:
+    provider: google
+    property: G-XXXXXXXXXX
+
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
## Summary
- allow configuring Google Analytics through `extra.analytics`
- mention analytics setup in README

## Testing
- `mkdocs build -q`

------
https://chatgpt.com/codex/tasks/task_e_6869976bced8832fa7fd6e701de15f85